### PR TITLE
add travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: go


### PR DESCRIPTION
Let's add Travis CI builds following https://docs.travis-ci.com/user/getting-started/.  If you would like to give me the rights I'll be happy to do it like in github.com/yahoo/webseclab (perhaps followed by https://coveralls.io/ as well).
