### PR TITLE
address a number of golint findings

### DIFF
--- a/rdl/http_util.go
+++ b/rdl/http_util.go
@@ -13,8 +13,7 @@ import (
 
 // for client/server generated code support
 
-//
-// Context is the context for a handler callout, in case access to the underlying request information is needed.
+// ResourceContext is the context for a handler callout, in case access to the underlying request information is needed.
 // Because explicit arguments are declared in the API with RDL (include path, query, and header params), the
 // need to access this is rare.
 // Note that the map of name to value is not protected for concurrency - the app must do this itself if it plans
@@ -29,7 +28,7 @@ type ResourceContext struct {
 }
 
 //
-// Get - returns an application data value on the context
+// Get - returns an application data value on the context.
 //
 func (ctx *ResourceContext) Get(name string) interface{} {
 	if ctx.Values != nil {
@@ -65,6 +64,7 @@ func (e ResourceError) Error() string {
 	return fmt.Sprintf("%d %s", e.Code, e.Message)
 }
 
+// JSONResponse provides response encoded as JSON.
 func JSONResponse(w http.ResponseWriter, code int, data interface{}) {
 	w.WriteHeader(code)
 	switch code {
@@ -83,6 +83,8 @@ func JSONResponse(w http.ResponseWriter, code int, data interface{}) {
 	}
 }
 
+// OptionalStringParam parses and returns an optional parameter
+// from the form body (multipart/form-data encoded).
 func OptionalStringParam(r *http.Request, name string) string {
 	if r.Form == nil {
 		r.ParseMultipartForm(32 << 20)
@@ -232,7 +234,8 @@ func HeaderParam(r *http.Request, name string, defaultValue string) string {
 	return val
 }
 
-//Go misfeature: all headers are canonicalizer as Capslike-This (for a header "CapsLike-this").
+// FoldHttpHeaderName adapts to the Go misfeature: all headers are
+// canonicalized as Capslike-This (for a header "CapsLike-this").
 func FoldHttpHeaderName(name string) string {
 	return http.CanonicalHeaderKey(name)
 }

--- a/rdl/parser.go
+++ b/rdl/parser.go
@@ -37,7 +37,7 @@ func (p *parser) String() string {
 	return "<scanner " + p.scanner.Filename + ">"
 }
 
-// ParseRDLFile parses the specified file to produce a Schema object
+// ParseRDLFile parses the specified file to produce a Schema object.
 func ParseRDLFile(path string, verbose bool, pedantic bool, nowarn bool) (*Schema, error) {
 	return parseRDLFile(path, nil, verbose, pedantic, nowarn)
 }

--- a/rdl/schema.go
+++ b/rdl/schema.go
@@ -13,7 +13,7 @@ var _ = json.Marshal
 var _ = fmt.Printf
 
 //
-// Identifier - All names need to be of this restricted string type
+// Identifier - All names need to be of this restricted string type.
 //
 type Identifier string
 
@@ -24,7 +24,7 @@ type Identifier string
 type NamespacedIdentifier string
 
 //
-// TypeName - The identifier for an already-defined type
+// TypeName - The identifier for an already-defined type.
 //
 type TypeName string
 
@@ -34,7 +34,7 @@ type TypeName string
 type TypeRef string
 
 //
-// BaseType -
+// BaseType is enumeration type.
 //
 type BaseType int
 
@@ -85,7 +85,7 @@ var namesBaseType = []string{
 }
 
 //
-// NewBaseType - return a string representation of the enum
+// NewBaseType returns a string representation of the enum.
 //
 func NewBaseType(init ...interface{}) BaseType {
 	if len(init) == 1 {
@@ -110,28 +110,28 @@ func NewBaseType(init ...interface{}) BaseType {
 }
 
 //
-// String - return a string representation of the enum
+// String returns a string representation of the enum.
 //
 func (e BaseType) String() string {
 	return namesBaseType[e]
 }
 
 //
-// SymbolSet - return an array of all valid string representations (symbols) of the enum
+// SymbolSet returns an array of all valid string representations (symbols) of the enum.
 //
 func (e BaseType) SymbolSet() []string {
 	return namesBaseType
 }
 
 //
-// MarshalJSON is defined for proper JSON encoding of a BaseType
+// MarshalJSON is defined for proper JSON encoding of a BaseType.
 //
 func (e BaseType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(e.String())
 }
 
 //
-// UnmarshalJSON is defined for proper JSON decoding of a BaseType
+// UnmarshalJSON is defined for proper JSON decoding of a BaseType.
 //
 func (e *BaseType) UnmarshalJSON(b []byte) error {
 	var j string
@@ -185,7 +185,7 @@ type TypeDef struct {
 }
 
 //
-// NewTypeDef - creates an initialized TypeDef instance, returns a pointer to it
+// NewTypeDef - creates an initialized TypeDef instance, returns a pointer to it.
 //
 func NewTypeDef(init ...*TypeDef) *TypeDef {
 	var o *TypeDef
@@ -200,7 +200,7 @@ func NewTypeDef(init ...*TypeDef) *TypeDef {
 type rawTypeDef TypeDef
 
 //
-// UnmarshalJSON is defined for proper JSON decoding of a TypeDef
+// UnmarshalJSON is defined for proper JSON decoding of a TypeDef.
 //
 func (pTypeDef *TypeDef) UnmarshalJSON(b []byte) error {
 	var r rawTypeDef
@@ -214,31 +214,29 @@ func (pTypeDef *TypeDef) UnmarshalJSON(b []byte) error {
 }
 
 //
-// Validate - checks for missing required fields, etc
+// Validate - checks for missing required fields, etc.
 //
 func (pTypeDef *TypeDef) Validate() error {
 	if pTypeDef.Type == "" {
 		return fmt.Errorf("TypeDef.type is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
-		if !val.Valid {
-			return fmt.Errorf("TypeDef.type does not contain a valid TypeRef (%v)", val.Error)
-		}
+	}
+	val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
+	if !val.Valid {
+		return fmt.Errorf("TypeDef.type does not contain a valid TypeRef (%v)", val.Error)
 	}
 	if pTypeDef.Name == "" {
 		return fmt.Errorf("TypeDef.name is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeName", pTypeDef.Name)
-		if !val.Valid {
-			return fmt.Errorf("TypeDef.name does not contain a valid TypeName (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "TypeName", pTypeDef.Name)
+	if !val.Valid {
+		return fmt.Errorf("TypeDef.name does not contain a valid TypeName (%v)", val.Error)
 	}
 	return nil
 }
 
 //
 // AliasTypeDef - AliasTypeDef is used for type definitions that add no
-// additional attributes, and thus just create an alias
+// additional attributes, and thus just create an alias.
 //
 type AliasTypeDef struct {
 
@@ -265,7 +263,7 @@ type AliasTypeDef struct {
 }
 
 //
-// NewAliasTypeDef - creates an initialized AliasTypeDef instance, returns a pointer to it
+// NewAliasTypeDef - creates an initialized AliasTypeDef instance, returns a pointer to it.
 //
 func NewAliasTypeDef(init ...*AliasTypeDef) *AliasTypeDef {
 	var o *AliasTypeDef
@@ -280,7 +278,7 @@ func NewAliasTypeDef(init ...*AliasTypeDef) *AliasTypeDef {
 type rawAliasTypeDef AliasTypeDef
 
 //
-// UnmarshalJSON is defined for proper JSON decoding of a AliasTypeDef
+// UnmarshalJSON is defined for proper JSON decoding of a AliasTypeDef.
 //
 func (pTypeDef *AliasTypeDef) UnmarshalJSON(b []byte) error {
 	var r rawAliasTypeDef
@@ -294,24 +292,22 @@ func (pTypeDef *AliasTypeDef) UnmarshalJSON(b []byte) error {
 }
 
 //
-// Validate - checks for missing required fields, etc
+// Validate checks for missing required fields, etc.
 //
 func (pTypeDef *AliasTypeDef) Validate() error {
 	if pTypeDef.Type == "" {
 		return fmt.Errorf("AliasTypeDef.type is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
-		if !val.Valid {
-			return fmt.Errorf("AliasTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
-		}
+	}
+	val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
+	if !val.Valid {
+		return fmt.Errorf("AliasTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
 	}
 	if pTypeDef.Name == "" {
 		return fmt.Errorf("AliasTypeDef.name is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeName", pTypeDef.Name)
-		if !val.Valid {
-			return fmt.Errorf("AliasTypeDef.name does not contain a valid TypeName (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "TypeName", pTypeDef.Name)
+	if !val.Valid {
+		return fmt.Errorf("AliasTypeDef.name does not contain a valid TypeName (%v)", val.Error)
 	}
 	return nil
 }
@@ -359,7 +355,7 @@ type BytesTypeDef struct {
 }
 
 //
-// NewBytesTypeDef - creates an initialized BytesTypeDef instance, returns a pointer to it
+// NewBytesTypeDef creates an initialized BytesTypeDef instance, returns a pointer to it.
 //
 func NewBytesTypeDef(init ...*BytesTypeDef) *BytesTypeDef {
 	var o *BytesTypeDef
@@ -374,7 +370,7 @@ func NewBytesTypeDef(init ...*BytesTypeDef) *BytesTypeDef {
 type rawBytesTypeDef BytesTypeDef
 
 //
-// UnmarshalJSON is defined for proper JSON decoding of a BytesTypeDef
+// UnmarshalJSON is defined for proper JSON decoding of a BytesTypeDef.
 //
 func (pTypeDef *BytesTypeDef) UnmarshalJSON(b []byte) error {
 	var r rawBytesTypeDef
@@ -388,31 +384,29 @@ func (pTypeDef *BytesTypeDef) UnmarshalJSON(b []byte) error {
 }
 
 //
-// Validate - checks for missing required fields, etc
+// Validate checks for missing required fields, etc.
 //
 func (pTypeDef *BytesTypeDef) Validate() error {
 	if pTypeDef.Type == "" {
 		return fmt.Errorf("BytesTypeDef.type is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
-		if !val.Valid {
-			return fmt.Errorf("BytesTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
-		}
+	}
+	val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
+	if !val.Valid {
+		return fmt.Errorf("BytesTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
 	}
 	if pTypeDef.Name == "" {
 		return fmt.Errorf("BytesTypeDef.name is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeName", pTypeDef.Name)
-		if !val.Valid {
-			return fmt.Errorf("BytesTypeDef.name does not contain a valid TypeName (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "TypeName", pTypeDef.Name)
+	if !val.Valid {
+		return fmt.Errorf("BytesTypeDef.name does not contain a valid TypeName (%v)", val.Error)
 	}
 	return nil
 }
 
 //
 // StringTypeDef - Strings allow the restriction by regular expression pattern
-// or by an explicit set of values. An optional maximum size may be asserted
+// or by an explicit set of values. An optional maximum size may be asserted.
 //
 type StringTypeDef struct {
 
@@ -459,7 +453,7 @@ type StringTypeDef struct {
 }
 
 //
-// NewStringTypeDef - creates an initialized StringTypeDef instance, returns a pointer to it
+// NewStringTypeDef creates an initialized StringTypeDef instance, returns a pointer to it.
 //
 func NewStringTypeDef(init ...*StringTypeDef) *StringTypeDef {
 	var o *StringTypeDef
@@ -474,7 +468,7 @@ func NewStringTypeDef(init ...*StringTypeDef) *StringTypeDef {
 type rawStringTypeDef StringTypeDef
 
 //
-// UnmarshalJSON is defined for proper JSON decoding of a StringTypeDef
+// UnmarshalJSON is defined for proper JSON decoding of a StringTypeDef.
 //
 func (pTypeDef *StringTypeDef) UnmarshalJSON(b []byte) error {
 	var r rawStringTypeDef
@@ -488,30 +482,28 @@ func (pTypeDef *StringTypeDef) UnmarshalJSON(b []byte) error {
 }
 
 //
-// Validate - checks for missing required fields, etc
+// Validate checks for missing required fields, etc.
 //
 func (pTypeDef *StringTypeDef) Validate() error {
 	if pTypeDef.Type == "" {
 		return fmt.Errorf("StringTypeDef.type is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
-		if !val.Valid {
-			return fmt.Errorf("StringTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
-		}
+	}
+	val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
+	if !val.Valid {
+		return fmt.Errorf("StringTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
 	}
 	if pTypeDef.Name == "" {
 		return fmt.Errorf("StringTypeDef.name is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeName", pTypeDef.Name)
-		if !val.Valid {
-			return fmt.Errorf("StringTypeDef.name does not contain a valid TypeName (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "TypeName", pTypeDef.Name)
+	if !val.Valid {
+		return fmt.Errorf("StringTypeDef.name does not contain a valid TypeName (%v)", val.Error)
 	}
 	return nil
 }
 
 //
-// NumberVariantTag - generated to support Number
+// NumberVariantTag is generated to support Number.
 //
 type NumberVariantTag int
 
@@ -529,7 +521,7 @@ const (
 )
 
 //
-// Number - A numeric is any of the primitive numeric types
+// Number - A numeric is any of the primitive numeric types.
 //
 type Number struct {
 	Variant NumberVariantTag `json:"-" rdl:"union"`
@@ -561,21 +553,21 @@ func (u Number) String() string {
 }
 
 //
-// Validate for Number
+// Validate for Number.
 //
-func (p *Number) Validate() error {
-	if p.Int8 != nil {
-		p.Variant = NumberVariantInt8
-	} else if p.Int16 != nil {
-		p.Variant = NumberVariantInt16
-	} else if p.Int32 != nil {
-		p.Variant = NumberVariantInt32
-	} else if p.Int64 != nil {
-		p.Variant = NumberVariantInt64
-	} else if p.Float32 != nil {
-		p.Variant = NumberVariantFloat32
-	} else if p.Float64 != nil {
-		p.Variant = NumberVariantFloat64
+func (u *Number) Validate() error {
+	if u.Int8 != nil {
+		u.Variant = NumberVariantInt8
+	} else if u.Int16 != nil {
+		u.Variant = NumberVariantInt16
+	} else if u.Int32 != nil {
+		u.Variant = NumberVariantInt32
+	} else if u.Int64 != nil {
+		u.Variant = NumberVariantInt64
+	} else if u.Float32 != nil {
+		u.Variant = NumberVariantFloat32
+	} else if u.Float64 != nil {
+		u.Variant = NumberVariantFloat64
 	} else {
 		return fmt.Errorf("Number: Missing required variant")
 	}
@@ -585,15 +577,15 @@ func (p *Number) Validate() error {
 type rawNumber Number
 
 //
-// UnmarshalJSON for Number
+// UnmarshalJSON for Number.
 //
-func (p *Number) UnmarshalJSON(b []byte) error {
+func (u *Number) UnmarshalJSON(b []byte) error {
 	var tmp rawNumber
 	if err := json.Unmarshal(b, &tmp); err != nil {
 		return err
 	}
-	*p = Number(tmp)
-	return p.Validate()
+	*u = Number(tmp)
+	return u.Validate()
 }
 
 //
@@ -635,7 +627,7 @@ type NumberTypeDef struct {
 }
 
 //
-// NewNumberTypeDef - creates an initialized NumberTypeDef instance, returns a pointer to it
+// NewNumberTypeDef creates an initialized NumberTypeDef instance, returns a pointer to it.
 //
 func NewNumberTypeDef(init ...*NumberTypeDef) *NumberTypeDef {
 	var o *NumberTypeDef
@@ -650,7 +642,7 @@ func NewNumberTypeDef(init ...*NumberTypeDef) *NumberTypeDef {
 type rawNumberTypeDef NumberTypeDef
 
 //
-// UnmarshalJSON is defined for proper JSON decoding of a NumberTypeDef
+// UnmarshalJSON is defined for proper JSON decoding of a NumberTypeDef.
 //
 func (pTypeDef *NumberTypeDef) UnmarshalJSON(b []byte) error {
 	var r rawNumberTypeDef
@@ -664,30 +656,28 @@ func (pTypeDef *NumberTypeDef) UnmarshalJSON(b []byte) error {
 }
 
 //
-// Validate - checks for missing required fields, etc
+// Validate checks for missing required fields, etc.
 //
 func (pTypeDef *NumberTypeDef) Validate() error {
 	if pTypeDef.Type == "" {
 		return fmt.Errorf("NumberTypeDef.type is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
-		if !val.Valid {
-			return fmt.Errorf("NumberTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
-		}
+	}
+	val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
+	if !val.Valid {
+		return fmt.Errorf("NumberTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
 	}
 	if pTypeDef.Name == "" {
 		return fmt.Errorf("NumberTypeDef.name is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeName", pTypeDef.Name)
-		if !val.Valid {
-			return fmt.Errorf("NumberTypeDef.name does not contain a valid TypeName (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "TypeName", pTypeDef.Name)
+	if !val.Valid {
+		return fmt.Errorf("NumberTypeDef.name does not contain a valid TypeName (%v)", val.Error)
 	}
 	return nil
 }
 
 //
-// ArrayTypeDef - Array types can be restricted by item type and size
+// ArrayTypeDef - Array types can be restricted by item type and size.
 //
 type ArrayTypeDef struct {
 
@@ -734,7 +724,7 @@ type ArrayTypeDef struct {
 }
 
 //
-// NewArrayTypeDef - creates an initialized ArrayTypeDef instance, returns a pointer to it
+// NewArrayTypeDef creates an initialized ArrayTypeDef instance, returns a pointer to it.
 //
 func NewArrayTypeDef(init ...*ArrayTypeDef) *ArrayTypeDef {
 	var o *ArrayTypeDef
@@ -747,7 +737,7 @@ func NewArrayTypeDef(init ...*ArrayTypeDef) *ArrayTypeDef {
 }
 
 //
-// Init - sets up the instance according to its default field values, if any
+// Init sets up the instance according to its default field values, if any.
 //
 func (pTypeDef *ArrayTypeDef) Init() *ArrayTypeDef {
 	if pTypeDef.Items == "" {
@@ -759,7 +749,7 @@ func (pTypeDef *ArrayTypeDef) Init() *ArrayTypeDef {
 type rawArrayTypeDef ArrayTypeDef
 
 //
-// UnmarshalJSON is defined for proper JSON decoding of a ArrayTypeDef
+// UnmarshalJSON is defined for proper JSON decoding of a ArrayTypeDef.
 //
 func (pTypeDef *ArrayTypeDef) UnmarshalJSON(b []byte) error {
 	var r rawArrayTypeDef
@@ -773,38 +763,35 @@ func (pTypeDef *ArrayTypeDef) UnmarshalJSON(b []byte) error {
 }
 
 //
-// Validate - checks for missing required fields, etc
+// Validate - checks for missing required fields, etc.
 //
 func (pTypeDef *ArrayTypeDef) Validate() error {
 	if pTypeDef.Type == "" {
 		return fmt.Errorf("ArrayTypeDef.type is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
-		if !val.Valid {
-			return fmt.Errorf("ArrayTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
-		}
+	}
+	val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
+	if !val.Valid {
+		return fmt.Errorf("ArrayTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
 	}
 	if pTypeDef.Name == "" {
 		return fmt.Errorf("ArrayTypeDef.name is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeName", pTypeDef.Name)
-		if !val.Valid {
-			return fmt.Errorf("ArrayTypeDef.name does not contain a valid TypeName (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "TypeName", pTypeDef.Name)
+	if !val.Valid {
+		return fmt.Errorf("ArrayTypeDef.name does not contain a valid TypeName (%v)", val.Error)
 	}
 	if pTypeDef.Items == "" {
 		return fmt.Errorf("ArrayTypeDef.items is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Items)
-		if !val.Valid {
-			return fmt.Errorf("ArrayTypeDef.items does not contain a valid TypeRef (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "TypeRef", pTypeDef.Items)
+	if !val.Valid {
+		return fmt.Errorf("ArrayTypeDef.items does not contain a valid TypeRef (%v)", val.Error)
 	}
 	return nil
 }
 
 //
-// MapTypeDef - Map types can be restricted by key type, item type and size
+// MapTypeDef - Map types can be restricted by key type, item type and size.
 //
 type MapTypeDef struct {
 
@@ -856,7 +843,7 @@ type MapTypeDef struct {
 }
 
 //
-// NewMapTypeDef - creates an initialized MapTypeDef instance, returns a pointer to it
+// NewMapTypeDef creates an initialized MapTypeDef instance, returns a pointer to it.
 //
 func NewMapTypeDef(init ...*MapTypeDef) *MapTypeDef {
 	var o *MapTypeDef
@@ -869,7 +856,7 @@ func NewMapTypeDef(init ...*MapTypeDef) *MapTypeDef {
 }
 
 //
-// Init - sets up the instance according to its default field values, if any
+// Init sets up the instance according to its default field values, if any.
 //
 func (pTypeDef *MapTypeDef) Init() *MapTypeDef {
 	if pTypeDef.Keys == "" {
@@ -884,7 +871,7 @@ func (pTypeDef *MapTypeDef) Init() *MapTypeDef {
 type rawMapTypeDef MapTypeDef
 
 //
-// UnmarshalJSON is defined for proper JSON decoding of a MapTypeDef
+// UnmarshalJSON is defined for proper JSON decoding of a MapTypeDef.
 //
 func (pTypeDef *MapTypeDef) UnmarshalJSON(b []byte) error {
 	var r rawMapTypeDef
@@ -898,46 +885,42 @@ func (pTypeDef *MapTypeDef) UnmarshalJSON(b []byte) error {
 }
 
 //
-// Validate - checks for missing required fields, etc
+// Validate - checks for missing required fields, etc.
 //
 func (pTypeDef *MapTypeDef) Validate() error {
 	if pTypeDef.Type == "" {
 		return fmt.Errorf("MapTypeDef.type is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
-		if !val.Valid {
-			return fmt.Errorf("MapTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
-		}
+	}
+	val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
+	if !val.Valid {
+		return fmt.Errorf("MapTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
 	}
 	if pTypeDef.Name == "" {
 		return fmt.Errorf("MapTypeDef.name is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeName", pTypeDef.Name)
-		if !val.Valid {
-			return fmt.Errorf("MapTypeDef.name does not contain a valid TypeName (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "TypeName", pTypeDef.Name)
+	if !val.Valid {
+		return fmt.Errorf("MapTypeDef.name does not contain a valid TypeName (%v)", val.Error)
 	}
 	if pTypeDef.Keys == "" {
 		return fmt.Errorf("MapTypeDef.keys is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Keys)
-		if !val.Valid {
-			return fmt.Errorf("MapTypeDef.keys does not contain a valid TypeRef (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "TypeRef", pTypeDef.Keys)
+	if !val.Valid {
+		return fmt.Errorf("MapTypeDef.keys does not contain a valid TypeRef (%v)", val.Error)
 	}
 	if pTypeDef.Items == "" {
 		return fmt.Errorf("MapTypeDef.items is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Items)
-		if !val.Valid {
-			return fmt.Errorf("MapTypeDef.items does not contain a valid TypeRef (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "TypeRef", pTypeDef.Items)
+	if !val.Valid {
+		return fmt.Errorf("MapTypeDef.items does not contain a valid TypeRef (%v)", val.Error)
 	}
 	return nil
 }
 
 //
-// StructFieldDef - Each field in a struct_field_spec is defined by this type
+// StructFieldDef - Each field in a struct_field_spec is defined by this type.
 //
 type StructFieldDef struct {
 
@@ -983,7 +966,7 @@ type StructFieldDef struct {
 }
 
 //
-// NewStructFieldDef - creates an initialized StructFieldDef instance, returns a pointer to it
+// NewStructFieldDef - creates an initialized StructFieldDef instance, returns a pointer to it.
 //
 func NewStructFieldDef(init ...*StructFieldDef) *StructFieldDef {
 	var o *StructFieldDef
@@ -998,7 +981,7 @@ func NewStructFieldDef(init ...*StructFieldDef) *StructFieldDef {
 type rawStructFieldDef StructFieldDef
 
 //
-// UnmarshalJSON is defined for proper JSON decoding of a StructFieldDef
+// UnmarshalJSON is defined for proper JSON decoding of a StructFieldDef.
 //
 func (pTypeDef *StructFieldDef) UnmarshalJSON(b []byte) error {
 	var r rawStructFieldDef
@@ -1012,24 +995,22 @@ func (pTypeDef *StructFieldDef) UnmarshalJSON(b []byte) error {
 }
 
 //
-// Validate - checks for missing required fields, etc
+// Validate checks for missing required fields, etc.
 //
 func (pTypeDef *StructFieldDef) Validate() error {
 	if pTypeDef.Name == "" {
 		return fmt.Errorf("StructFieldDef.name is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "Identifier", pTypeDef.Name)
-		if !val.Valid {
-			return fmt.Errorf("StructFieldDef.name does not contain a valid Identifier (%v)", val.Error)
-		}
+	}
+	val := Validate(RdlSchema(), "Identifier", pTypeDef.Name)
+	if !val.Valid {
+		return fmt.Errorf("StructFieldDef.name does not contain a valid Identifier (%v)", val.Error)
 	}
 	if pTypeDef.Type == "" {
 		return fmt.Errorf("StructFieldDef.type is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
-		if !val.Valid {
-			return fmt.Errorf("StructFieldDef.type does not contain a valid TypeRef (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
+	if !val.Valid {
+		return fmt.Errorf("StructFieldDef.type does not contain a valid TypeRef (%v)", val.Error)
 	}
 	return nil
 }
@@ -1037,7 +1018,7 @@ func (pTypeDef *StructFieldDef) Validate() error {
 //
 // StructTypeDef - A struct can restrict specific named fields to specific
 // types. By default, any field not specified is allowed, and can be of any
-// type. Specifying closed means only those fields explicitly
+// type. Specifying closed means only those fields explicitly.
 //
 type StructTypeDef struct {
 
@@ -1076,7 +1057,7 @@ type StructTypeDef struct {
 }
 
 //
-// NewStructTypeDef - creates an initialized StructTypeDef instance, returns a pointer to it
+// NewStructTypeDef creates an initialized StructTypeDef instance, returns a pointer to it.
 //
 func NewStructTypeDef(init ...*StructTypeDef) *StructTypeDef {
 	var o *StructTypeDef
@@ -1089,7 +1070,7 @@ func NewStructTypeDef(init ...*StructTypeDef) *StructTypeDef {
 }
 
 //
-// Init - sets up the instance according to its default field values, if any
+// Init sets up the instance according to its default field values, if any.
 //
 func (pTypeDef *StructTypeDef) Init() *StructTypeDef {
 	if pTypeDef.Fields == nil {
@@ -1101,7 +1082,7 @@ func (pTypeDef *StructTypeDef) Init() *StructTypeDef {
 type rawStructTypeDef StructTypeDef
 
 //
-// UnmarshalJSON is defined for proper JSON decoding of a StructTypeDef
+// UnmarshalJSON is defined for proper JSON decoding of a StructTypeDef.
 //
 func (pTypeDef *StructTypeDef) UnmarshalJSON(b []byte) error {
 	var r rawStructTypeDef
@@ -1115,24 +1096,22 @@ func (pTypeDef *StructTypeDef) UnmarshalJSON(b []byte) error {
 }
 
 //
-// Validate - checks for missing required fields, etc
+// Validate - checks for missing required fields, etc.
 //
 func (pTypeDef *StructTypeDef) Validate() error {
 	if pTypeDef.Type == "" {
 		return fmt.Errorf("StructTypeDef.type is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
-		if !val.Valid {
-			return fmt.Errorf("StructTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
-		}
+	}
+	val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
+	if !val.Valid {
+		return fmt.Errorf("StructTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
 	}
 	if pTypeDef.Name == "" {
 		return fmt.Errorf("StructTypeDef.name is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeName", pTypeDef.Name)
-		if !val.Valid {
-			return fmt.Errorf("StructTypeDef.name does not contain a valid TypeName (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "TypeName", pTypeDef.Name)
+	if !val.Valid {
+		return fmt.Errorf("StructTypeDef.name does not contain a valid TypeName (%v)", val.Error)
 	}
 	if pTypeDef.Fields == nil {
 		return fmt.Errorf("StructTypeDef: Missing required field: fields")
@@ -1191,12 +1170,12 @@ func (pTypeDef *EnumElementDef) UnmarshalJSON(b []byte) error {
 func (pTypeDef *EnumElementDef) Validate() error {
 	if pTypeDef.Symbol == "" {
 		return fmt.Errorf("EnumElementDef.symbol is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "Identifier", pTypeDef.Symbol)
-		if !val.Valid {
-			return fmt.Errorf("EnumElementDef.symbol does not contain a valid Identifier (%v)", val.Error)
-		}
 	}
+	val := Validate(RdlSchema(), "Identifier", pTypeDef.Symbol)
+	if !val.Valid {
+		return fmt.Errorf("EnumElementDef.symbol does not contain a valid Identifier (%v)", val.Error)
+	}
+
 	return nil
 }
 
@@ -1259,7 +1238,7 @@ func (pTypeDef *EnumTypeDef) Init() *EnumTypeDef {
 type rawEnumTypeDef EnumTypeDef
 
 //
-// UnmarshalJSON is defined for proper JSON decoding of a EnumTypeDef
+// UnmarshalJSON is defined for proper JSON decoding of a EnumTypeDef.
 //
 func (pTypeDef *EnumTypeDef) UnmarshalJSON(b []byte) error {
 	var r rawEnumTypeDef
@@ -1273,24 +1252,22 @@ func (pTypeDef *EnumTypeDef) UnmarshalJSON(b []byte) error {
 }
 
 //
-// Validate - checks for missing required fields, etc
+// Validate - checks for missing required fields, etc.
 //
 func (pTypeDef *EnumTypeDef) Validate() error {
 	if pTypeDef.Type == "" {
 		return fmt.Errorf("EnumTypeDef.type is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
-		if !val.Valid {
-			return fmt.Errorf("EnumTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
-		}
+	}
+	val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
+	if !val.Valid {
+		return fmt.Errorf("EnumTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
 	}
 	if pTypeDef.Name == "" {
 		return fmt.Errorf("EnumTypeDef.name is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeName", pTypeDef.Name)
-		if !val.Valid {
-			return fmt.Errorf("EnumTypeDef.name does not contain a valid TypeName (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "TypeName", pTypeDef.Name)
+	if !val.Valid {
+		return fmt.Errorf("EnumTypeDef.name does not contain a valid TypeName (%v)", val.Error)
 	}
 	if pTypeDef.Elements == nil {
 		return fmt.Errorf("EnumTypeDef: Missing required field: elements")
@@ -1332,7 +1309,7 @@ type UnionTypeDef struct {
 }
 
 //
-// NewUnionTypeDef - creates an initialized UnionTypeDef instance, returns a pointer to it
+// NewUnionTypeDef - creates an initialized UnionTypeDef instance, returns a pointer to it.
 //
 func NewUnionTypeDef(init ...*UnionTypeDef) *UnionTypeDef {
 	var o *UnionTypeDef
@@ -1345,7 +1322,7 @@ func NewUnionTypeDef(init ...*UnionTypeDef) *UnionTypeDef {
 }
 
 //
-// Init - sets up the instance according to its default field values, if any
+// Init - sets up the instance according to its default field values, if any.
 //
 func (pTypeDef *UnionTypeDef) Init() *UnionTypeDef {
 	if pTypeDef.Variants == nil {
@@ -1357,7 +1334,7 @@ func (pTypeDef *UnionTypeDef) Init() *UnionTypeDef {
 type rawUnionTypeDef UnionTypeDef
 
 //
-// UnmarshalJSON is defined for proper JSON decoding of a UnionTypeDef
+// UnmarshalJSON is defined for proper JSON decoding of a UnionTypeDef.
 //
 func (pTypeDef *UnionTypeDef) UnmarshalJSON(b []byte) error {
 	var r rawUnionTypeDef
@@ -1371,24 +1348,23 @@ func (pTypeDef *UnionTypeDef) UnmarshalJSON(b []byte) error {
 }
 
 //
-// Validate - checks for missing required fields, etc
+// Validate - checks for missing required fields, etc.
 //
 func (pTypeDef *UnionTypeDef) Validate() error {
 	if pTypeDef.Type == "" {
 		return fmt.Errorf("UnionTypeDef.type is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
-		if !val.Valid {
-			return fmt.Errorf("UnionTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
-		}
 	}
+	val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
+	if !val.Valid {
+		return fmt.Errorf("UnionTypeDef.type does not contain a valid TypeRef (%v)", val.Error)
+	}
+
 	if pTypeDef.Name == "" {
 		return fmt.Errorf("UnionTypeDef.name is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeName", pTypeDef.Name)
-		if !val.Valid {
-			return fmt.Errorf("UnionTypeDef.name does not contain a valid TypeName (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "TypeName", pTypeDef.Name)
+	if !val.Valid {
+		return fmt.Errorf("UnionTypeDef.name does not contain a valid TypeName (%v)", val.Error)
 	}
 	if pTypeDef.Variants == nil {
 		return fmt.Errorf("UnionTypeDef: Missing required field: variants")
@@ -1420,7 +1396,7 @@ const (
 
 //
 // Type - A Type can be specified by any of the above specialized Types,
-// determined by the value of the the 'type' field
+// determined by the value of the the 'type' field.
 //
 type Type struct {
 	Variant       TypeVariantTag `json:"-" rdl:"union"`
@@ -1604,19 +1580,18 @@ func (pTypeDef *ResourceInput) UnmarshalJSON(b []byte) error {
 func (pTypeDef *ResourceInput) Validate() error {
 	if pTypeDef.Name == "" {
 		return fmt.Errorf("ResourceInput.name is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "Identifier", pTypeDef.Name)
-		if !val.Valid {
-			return fmt.Errorf("ResourceInput.name does not contain a valid Identifier (%v)", val.Error)
-		}
 	}
+	val := Validate(RdlSchema(), "Identifier", pTypeDef.Name)
+	if !val.Valid {
+		return fmt.Errorf("ResourceInput.name does not contain a valid Identifier (%v)", val.Error)
+	}
+
 	if pTypeDef.Type == "" {
 		return fmt.Errorf("ResourceInput.type is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
-		if !val.Valid {
-			return fmt.Errorf("ResourceInput.type does not contain a valid TypeRef (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
+	if !val.Valid {
+		return fmt.Errorf("ResourceInput.type does not contain a valid TypeRef (%v)", val.Error)
 	}
 	return nil
 }
@@ -1687,27 +1662,24 @@ func (pTypeDef *ResourceOutput) UnmarshalJSON(b []byte) error {
 func (pTypeDef *ResourceOutput) Validate() error {
 	if pTypeDef.Name == "" {
 		return fmt.Errorf("ResourceOutput.name is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "Identifier", pTypeDef.Name)
-		if !val.Valid {
-			return fmt.Errorf("ResourceOutput.name does not contain a valid Identifier (%v)", val.Error)
-		}
+	}
+	val := Validate(RdlSchema(), "Identifier", pTypeDef.Name)
+	if !val.Valid {
+		return fmt.Errorf("ResourceOutput.name does not contain a valid Identifier (%v)", val.Error)
 	}
 	if pTypeDef.Type == "" {
 		return fmt.Errorf("ResourceOutput.type is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
-		if !val.Valid {
-			return fmt.Errorf("ResourceOutput.type does not contain a valid TypeRef (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
+	if !val.Valid {
+		return fmt.Errorf("ResourceOutput.type does not contain a valid TypeRef (%v)", val.Error)
 	}
 	if pTypeDef.Header == "" {
 		return fmt.Errorf("ResourceOutput.header is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "String", pTypeDef.Header)
-		if !val.Valid {
-			return fmt.Errorf("ResourceOutput.header does not contain a valid String (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "String", pTypeDef.Header)
+	if !val.Valid {
+		return fmt.Errorf("ResourceOutput.header does not contain a valid String (%v)", val.Error)
 	}
 	return nil
 }
@@ -1829,11 +1801,10 @@ func (pTypeDef *ExceptionDef) UnmarshalJSON(b []byte) error {
 func (pTypeDef *ExceptionDef) Validate() error {
 	if pTypeDef.Type == "" {
 		return fmt.Errorf("ExceptionDef.type is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "String", pTypeDef.Type)
-		if !val.Valid {
-			return fmt.Errorf("ExceptionDef.type does not contain a valid String (%v)", val.Error)
-		}
+	}
+	val := Validate(RdlSchema(), "String", pTypeDef.Type)
+	if !val.Valid {
+		return fmt.Errorf("ExceptionDef.type does not contain a valid String (%v)", val.Error)
 	}
 	return nil
 }
@@ -1940,40 +1911,36 @@ func (pTypeDef *Resource) UnmarshalJSON(b []byte) error {
 }
 
 //
-// Validate - checks for missing required fields, etc
+// Validate - checks for missing required fields, etc.
 //
 func (pTypeDef *Resource) Validate() error {
 	if pTypeDef.Type == "" {
 		return fmt.Errorf("Resource.type is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
-		if !val.Valid {
-			return fmt.Errorf("Resource.type does not contain a valid TypeRef (%v)", val.Error)
-		}
+	}
+	val := Validate(RdlSchema(), "TypeRef", pTypeDef.Type)
+	if !val.Valid {
+		return fmt.Errorf("Resource.type does not contain a valid TypeRef (%v)", val.Error)
 	}
 	if pTypeDef.Method == "" {
 		return fmt.Errorf("Resource.method is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "String", pTypeDef.Method)
-		if !val.Valid {
-			return fmt.Errorf("Resource.method does not contain a valid String (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "String", pTypeDef.Method)
+	if !val.Valid {
+		return fmt.Errorf("Resource.method does not contain a valid String (%v)", val.Error)
 	}
 	if pTypeDef.Path == "" {
 		return fmt.Errorf("Resource.path is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "String", pTypeDef.Path)
-		if !val.Valid {
-			return fmt.Errorf("Resource.path does not contain a valid String (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "String", pTypeDef.Path)
+	if !val.Valid {
+		return fmt.Errorf("Resource.path does not contain a valid String (%v)", val.Error)
 	}
 	if pTypeDef.Expected == "" {
 		return fmt.Errorf("Resource.expected is missing but is a required field")
-	} else {
-		val := Validate(RdlSchema(), "String", pTypeDef.Expected)
-		if !val.Valid {
-			return fmt.Errorf("Resource.expected does not contain a valid String (%v)", val.Error)
-		}
+	}
+	val = Validate(RdlSchema(), "String", pTypeDef.Expected)
+	if !val.Valid {
+		return fmt.Errorf("Resource.expected does not contain a valid String (%v)", val.Error)
 	}
 	return nil
 }
@@ -2031,7 +1998,7 @@ func NewSchema(init ...*Schema) *Schema {
 type rawSchema Schema
 
 //
-// UnmarshalJSON is defined for proper JSON decoding of a Schema
+// UnmarshalJSON is defined for proper JSON decoding of a Schema.
 //
 func (pTypeDef *Schema) UnmarshalJSON(b []byte) error {
 	var r rawSchema
@@ -2045,7 +2012,7 @@ func (pTypeDef *Schema) UnmarshalJSON(b []byte) error {
 }
 
 //
-// Validate - checks for missing required fields, etc
+// Validate checks for missing required fields, etc.
 //
 func (pTypeDef *Schema) Validate() error {
 	return nil

--- a/rdl/timestamp.go
+++ b/rdl/timestamp.go
@@ -122,7 +122,7 @@ func NewTimestamp(t time.Time) Timestamp {
 }
 
 //
-// NewTimestamp - create a new Timestamp from the specified time.Time
+// TimestampFromEpoch creates a new Timestamp from the specified time.Time
 //
 func TimestampFromEpoch(secondsSinceEpoch float64) Timestamp {
 	sec := int64(secondsSinceEpoch)

--- a/rdl/types.go
+++ b/rdl/types.go
@@ -74,7 +74,7 @@ func (reg *typeRegistry) FindType(name TypeRef) *Type {
 	return nil
 }
 
-//return common info that every type shares
+// TypeInfo returns common info that every type shares.
 func TypeInfo(t *Type) (TypeName, TypeRef, string) {
 	switch t.Variant {
 	case TypeVariantAliasTypeDef:

--- a/rdl/uuid.go
+++ b/rdl/uuid.go
@@ -49,11 +49,12 @@ func ParseUUID(s string) UUID {
 		14, 16,
 		19, 21,
 		24, 26, 28, 30, 32, 34} {
-		if v, err := strconv.ParseInt(s[x:x+2], 16, 16); err != nil {
+		var v int64
+		var err error
+		if v, err = strconv.ParseInt(s[x:x+2], 16, 16); err != nil {
 			return nil
-		} else {
-			uuid[i] = byte(v)
 		}
+		uuid[i] = byte(v)
 	}
 	return uuid
 }
@@ -69,33 +70,33 @@ func NewUUID(b []byte) UUID {
 }
 
 //
-// String - produce the standard "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" representaion of a UUID
+// String produces the standard "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" representaion of a UUID.
 //
-func (uuid UUID) String() string {
-	if uuid == nil || len(uuid) != 16 {
+func (u UUID) String() string {
+	if u == nil || len(u) != 16 {
 		return "00000000-0000-0000-0000-000000000000"
 	}
-	b := []byte(uuid)
+	b := []byte(u)
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[:4], b[4:6], b[6:8], b[8:10], b[10:])
 }
 
 //
-// MarshalJSON - produce the standard format for a UUID as a JSON string
+// MarshalJSON produces the standard format for a UUID as a JSON string.
 //
-func (uuid UUID) MarshalJSON() ([]byte, error) {
-	return []byte("\"" + uuid.String() + "\""), nil
+func (u UUID) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + u.String() + "\""), nil
 }
 
 //
-// UnmarshalJSON - Parse a JSON string in standard UUID format
+// UnmarshalJSON parses a JSON string in standard UUID format.
 //
-func (uuid *UUID) UnmarshalJSON(b []byte) error {
+func (u *UUID) UnmarshalJSON(b []byte) error {
 	var j string
 	err := json.Unmarshal(b, &j)
 	if err == nil {
 		v := ParseUUID(string(j))
 		if v != nil {
-			*uuid = v
+			*u = v
 		} else {
 			err = fmt.Errorf("Bad UUID: %v", string(j))
 		}

--- a/tbin/basic_test.go
+++ b/tbin/basic_test.go
@@ -6,10 +6,11 @@ package tbin
 import (
 	"bytes"
 	"fmt"
-	"github.com/ardielle/ardielle-go/rdl"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/ardielle/ardielle-go/rdl"
 )
 
 var _ = testing.Verbose
@@ -129,7 +130,7 @@ func TestMarshalSimpleTypes(test *testing.T) {
 	i32 = -(0x7fffffff) - 1
 	tdata, err = Marshal(i32)
 	checkError(test, fmt.Sprintf("i32 %d", i32), tdata, err, -1, []byte{24, 4, 255, 255, 255, 255, 15})
-	var i int = 23
+	var i = 23
 	tdata, err = Marshal(i)
 	checkError(test, "i 23", tdata, err, -1, []byte{24, 4, 46})
 	var u32 uint32 = 0xffffffff

--- a/tbin/encoder.go
+++ b/tbin/encoder.go
@@ -11,9 +11,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/ardielle/ardielle-go/rdl"
 	"math"
 	"reflect"
+
+	"github.com/ardielle/ardielle-go/rdl"
 )
 
 //
@@ -257,10 +258,9 @@ func (enc *Encoder) EncodeString(val string) error {
 			_, enc.err = enc.buf.Write(utf8)
 		}
 		return enc.err
-	} else {
-		enc.writeUnsigned(StringTag)
-		return enc.WriteString(val)
 	}
+	enc.writeUnsigned(StringTag)
+	return enc.WriteString(val)
 }
 
 func (enc *Encoder) EncodeSymbol(val rdl.Symbol) error {
@@ -347,10 +347,9 @@ func (enc *Encoder) encodeValue(v reflect.Value, useMarshallable bool) error {
 				if nvar > 0 {
 					enc.tagged = true //ensure the next WriteType doesn't actually do anything
 					return enc.encodeValue(v.Field(nvar), useMarshallable)
-				} else {
-					enc.err = fmt.Errorf("Cannot marshal uninitialized union type %v in %v", t.Name, v)
-					return enc.err
 				}
+				enc.err = fmt.Errorf("Cannot marshal uninitialized union type %v in %v", t.Name, v)
+				return enc.err
 			}
 		}
 		for i := 0; i < nfields; i++ {
@@ -370,9 +369,8 @@ func (enc *Encoder) encodeValue(v reflect.Value, useMarshallable bool) error {
 					if f.IsNil() {
 						enc.err = fmt.Errorf("Cannot marshal null pointer for required field %v in %v", ft.Name, f)
 						return enc.err
-					} else {
-						err = enc.encodeValue(f.Elem(), useMarshallable)
 					}
+					err = enc.encodeValue(f.Elem(), useMarshallable)
 				} else {
 					err = enc.encodeValue(f, useMarshallable)
 				}
@@ -677,9 +675,9 @@ func (enc *Encoder) compileSignatureOptional(sig *Signature, ref *bytes.Buffer, 
 	return enc.err
 }
 
-// DefineTag - given a signature, write the tag for it. If it is the first time
+// WriteType takes a signature and writes the tag for it. If it is the first time
 // the signature has been encountered, a new tag is allocated and written followed
-// by its definition
+// by its definition.
 func (enc *Encoder) WriteType(sig *Signature) error {
 	if enc.tagged {
 		enc.tagged = false

--- a/tbin/test_common.go
+++ b/tbin/test_common.go
@@ -117,9 +117,8 @@ func rannotated(t reflect.Type, v reflect.Value) string {
 	case reflect.Ptr:
 		if v.IsNil() {
 			return "nil"
-		} else {
-			return "*" + annotated(v.Elem().Interface())
 		}
+		return "*" + annotated(v.Elem().Interface())
 	case reflect.String:
 		return fmt.Sprintf("string~%q", v.String())
 	case reflect.Bool:


### PR DESCRIPTION
fixed some of the issues picked up golint: http://go-lint.appspot.com/github.com/ardielle/ardielle-go/rdl.  Most of them relate to the Go's "early return" convention with the if clauses and some minor comment changes.

I realize that some of the changes in the generated code - possibly we can consider changing the generator (or just punt on those that are generated).  Also, would it make sense to add a warning to the generated files like `File generated by rdl version <x.y.z> from <template X> - DO NOT EDIT` ?
