### PR TITLE
go vet fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: go
+
+go: 1.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: go
 
 go: 1.6
+
+before_script:
+  - go vet ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-# ardielle-go
+# ardielle-go [![Build Status](https://travis-ci.org/ardielle/ardielle-go.svg?branch=master)](https://travis-ci.org/ardielle/ardielle-go)
+
 Go language support for RDL.
+
+Godoc API references:  
+* https://godoc.org/github.com/ardielle/ardielle-go/rdl
+* https://godoc.org/github.com/ardielle/ardielle-go/tbin  
 
 ## License
 

--- a/tbin/encoder.go
+++ b/tbin/encoder.go
@@ -348,7 +348,7 @@ func (enc *Encoder) encodeValue(v reflect.Value, useMarshallable bool) error {
 					enc.tagged = true //ensure the next WriteType doesn't actually do anything
 					return enc.encodeValue(v.Field(nvar), useMarshallable)
 				}
-				enc.err = fmt.Errorf("Cannot marshal uninitialized union type %v in %v", t.Name, v)
+				enc.err = fmt.Errorf("Cannot marshal uninitialized union type %s in %v", t.Name(), v)
 				return enc.err
 			}
 		}


### PR DESCRIPTION
`go tool vet ./...` currenty fails with:

```
tbin/encoder.go:351: arg t.Name in printf call is a function value, not a function call
```

The Name() function in reflect.Type interface returns a string:
https://golang.org/pkg/reflect/#Type

```
// Name returns the type's name within its package.
// It returns an empty string for unnamed types.
Name() string
```

Suggesting to break the builds on `go vet` errors for automatic CI verification from now on.

cc @boynton 
