### PR TITLE
Fixed issue 13

### DIFF
--- a/rdl/parser.go
+++ b/rdl/parser.go
@@ -1053,7 +1053,7 @@ func makeAliasType(typeName TypeName, supertypeName TypeRef, comment string) *Ty
 
 func (p *parser) usedFieldNames(tref TypeRef) map[Identifier]bool {
 	var fieldNames map[Identifier]bool
-	tt := p.registry.FindType(tref)
+	tt := p.findType(tref)
 	if tt.Variant == TypeVariantBaseType {
 		fieldNames = make(map[Identifier]bool)
 	} else if tt.Variant == TypeVariantStructTypeDef {

--- a/rdl/parser_test.go
+++ b/rdl/parser_test.go
@@ -212,3 +212,8 @@ type Node Struct {
 		test.Errorf("cannot parse valid RDL: %v", err)
 	}
 }
+
+func TestIncludeTypeLookup(test *testing.T) {
+	//this tests that type lookup is correct across multiple included files
+	loadTestSchema(test, "k1_a.rdl")
+}

--- a/testdata/k1_a.rdl
+++ b/testdata/k1_a.rdl
@@ -1,0 +1,7 @@
+include "k1_c.rdl"
+include "k1_b.rdl"
+
+type A C {
+     String afield
+}
+

--- a/testdata/k1_b.rdl
+++ b/testdata/k1_b.rdl
@@ -1,0 +1,6 @@
+include "k1_c.rdl"
+
+type B C {
+     String bfield
+}
+

--- a/testdata/k1_c.rdl
+++ b/testdata/k1_c.rdl
@@ -1,0 +1,4 @@
+type C Struct {
+  String cfield
+}
+


### PR DESCRIPTION
type lookup was not the one that looks across multiple files in one
spot, yet _was_ in others, mismatch causes a panic. The test case
panics without the fix.
