### PR TITLE
Allow user to optional define alias for resources.

### DIFF
--- a/rdl/parser.go
+++ b/rdl/parser.go
@@ -1918,6 +1918,9 @@ func (p *parser) parseResource(comment string) *Resource {
 	tok := p.scanner.Scan()
 	for tok != scanner.EOF || p.err == nil {
 		if tok == '}' {
+			if rune := p.scanner.Peek(); rune != '\n' && rune != scanner.EOF {
+				r.Alias = p.identifier("symbol")
+			}
 			break
 		} else {
 			switch tok {

--- a/rdl/parser.go
+++ b/rdl/parser.go
@@ -1858,6 +1858,9 @@ func (p *parser) parseResourceOptions() map[ExtendedAnnotation]string {
 			switch strings.ToLower(optname) {
 			case "async":
 				options["async"] = ""
+			case "name":
+				p.expect("=")
+				options["name"] = string(p.identifier("resource name"))
 			default:
 				if strings.HasPrefix(optname, "x_") {
 					options = p.parseExtendedOption(options, ExtendedAnnotation(optname))
@@ -1906,6 +1909,10 @@ func (p *parser) parseResource(comment string) *Resource {
 				r.Async = &b
 				delete(options, "async")
 			}
+			if _, ok := options["name"]; ok {
+				r.Name = Identifier(options["name"])
+				delete(options, "name")
+			}
 		}
 		if len(options) > 0 {
 			r.Annotations = options
@@ -1918,9 +1925,6 @@ func (p *parser) parseResource(comment string) *Resource {
 	tok := p.scanner.Scan()
 	for tok != scanner.EOF || p.err == nil {
 		if tok == '}' {
-			if rune := p.scanner.Peek(); rune != '\n' && rune != scanner.EOF {
-				r.Alias = p.identifier("symbol")
-			}
 			break
 		} else {
 			switch tok {

--- a/rdl/parser_test.go
+++ b/rdl/parser_test.go
@@ -279,3 +279,29 @@ resource Any GET "/foo" {
 		}
 	}
 }
+
+func TestAlias(test *testing.T) {
+	schema, err := parseRDLString(`
+resource Any GET "/nil" {
+  expected OK;
+}
+
+resource Any GET "/foo" {
+  expected OK;
+} myFoo // comment to be ignored
+`)
+	if err != nil {
+		test.Errorf("cannot parse valid RDL with alias: %v", err)
+	} else {
+		if len(schema.Resources) != 2 {
+			test.Errorf("Did not parse expected number of resources: %v", schema)
+		}
+		if schema.Resources[0].Alias != "" {
+			test.Errorf("Did not parse alias correctly (expected nil)")
+		}
+		r := schema.Resources[1]
+		if r.Alias != "myFoo" {
+			test.Errorf("Did not parse alias correctly: %v (expected myFoo)", r.Alias)
+		}
+	}
+}

--- a/rdl/parser_test.go
+++ b/rdl/parser_test.go
@@ -280,28 +280,36 @@ resource Any GET "/foo" {
 	}
 }
 
-func TestAlias(test *testing.T) {
+func TestResourceName(test *testing.T) {
 	schema, err := parseRDLString(`
 resource Any GET "/nil" {
   expected OK;
 }
 
-resource Any GET "/foo" {
+resource Any GET "/foo" (name=myFoo) {
   expected OK;
-} myFoo // comment to be ignored
+}
+
+resource Any GET "/bar" (async, name    =  myBar, x_something   ) {
+  expected OK;
+}
 `)
 	if err != nil {
-		test.Errorf("cannot parse valid RDL with alias: %v", err)
+		test.Errorf("cannot parse valid RDL with resource name: %v", err)
 	} else {
-		if len(schema.Resources) != 2 {
+		if len(schema.Resources) != 3 {
 			test.Errorf("Did not parse expected number of resources: %v", schema)
 		}
-		if schema.Resources[0].Alias != "" {
-			test.Errorf("Did not parse alias correctly (expected nil)")
+		if schema.Resources[0].Name != "" {
+			test.Errorf("Did not parse resource name correctly (expected nil)")
 		}
 		r := schema.Resources[1]
-		if r.Alias != "myFoo" {
-			test.Errorf("Did not parse alias correctly: %v (expected myFoo)", r.Alias)
+		if r.Name != "myFoo" {
+			test.Errorf("Did not parse resource name correctly: %v (expected myFoo)", r.Name)
+		}
+		r = schema.Resources[2]
+		if r.Name != "myBar" {
+			test.Errorf("Did not parse resource name correctly: %v (expected myBar)", r.Name)
 		}
 	}
 }

--- a/rdl/schema.go
+++ b/rdl/schema.go
@@ -1924,9 +1924,10 @@ type Resource struct {
 	//
 	Produces []string `json:"produces,omitempty" rdl:"optional"`
 
-	// Optional resource alias
 	//
-	Alias Identifier `json:"alias,omitempty" rdl:"optional"`
+	// Optional resource name
+	//
+	Name Identifier `json:"name,omitempty" rdl:"optional"`
 }
 
 //

--- a/rdl/schema.go
+++ b/rdl/schema.go
@@ -1923,6 +1923,10 @@ type Resource struct {
 	// Optional hint for resource output content type.
 	//
 	Produces []string `json:"produces,omitempty" rdl:"optional"`
+
+	// Optional resource alias
+	//
+	Alias Identifier `json:"alias,omitempty" rdl:"optional"`
 }
 
 //


### PR DESCRIPTION
This PR enables the definition of an optional resource alias at the end of the endpoint definition (the idea is similar to the typedef definition of structs in C).  

It looks something like this:

```
resource MpNullResult DELETE "/toses" {
    authenticate;

    expected NO_CONTENT;
    exceptions {
        ResourceError INTERNAL_SERVER_ERROR; 
        ResourceError BAD_REQUEST;           
        ResourceError UNAUTHORIZED;       
        ResourceError FORBIDDEN;
    }
} deleteTos;
```

Thanks
