### PR TITLE
Add a unique method to ResourceError for easy type switch

### DIFF
--- a/rdl/http_util.go
+++ b/rdl/http_util.go
@@ -60,6 +60,10 @@ type ResourceError struct {
 
 }
 
+func (e ResourceError) StatusCode() int {
+	return e.Code
+}
+
 func (e ResourceError) Error() string {
 	return fmt.Sprintf("%d %s", e.Code, e.Message)
 }


### PR DESCRIPTION
It is currently difficult to type-switch on a ResourceError object
since some functions return values and others return pointers.

Adding a unique method to the struct allows the caller to typeswitch on
an interface without worrying about values or pointers.

Example: https://play.golang.org/p/bKw-1tl-8t