### PR TITLE
Fix alias type resolution for string patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 src
 Makefile
+*.iml

--- a/rdl/parser_test.go
+++ b/rdl/parser_test.go
@@ -100,6 +100,9 @@ func TestParse(test *testing.T) {
 	parseBadRDL(test, `type Foo Struct { String foo; } type Bar Foo { String foo; }`)
 	parseBadRDL(test, `type Foo Struct { String bar; } resource Foo GET "/foo?d={debug}" {String debug (optinal); }`)
 	parseGoodRDL(test, `type Foo Any; type X Struct { Any y; } type Y Struct { Foo y;}`)
+	parseGoodRDL(test, `type A String (pattern="[a-z]"); type B A; type C B; type D string (pattern="{C}-{A}");`)
+
+
 
 	schema, err := parseRDLString(`type Base Struct { String bar; } type Foo Base;`)
 	if err != nil {


### PR DESCRIPTION
Input such as:
```
type A String (pattern="[a-z]");
type B A;
type C string (pattern="{B}-{A}");
```

would cause a panic because there is no pattern associated with an
alias. Added a new parser method to resolve types used in patterns.