### PR TITLE
Fixed issue #36 in a better way

### DIFF
--- a/rdl/parser_test.go
+++ b/rdl/parser_test.go
@@ -51,6 +51,13 @@ func TestMapDefinition(t *testing.T) {
 	if schema == nil {
 		return
 	}
+	reg := NewTypeRegistry(schema)
+	ty := reg.FindType("AttachedVolume")
+	switch ty.Variant {
+	case TypeVariantMapTypeDef:
+	default:
+		t.Errorf("parsed Map type was inlined when it should not have been")
+	}
 }
 
 func TestBasicTypes(test *testing.T) {


### PR DESCRIPTION
It turns out it was an errant optimization that was trying to inline the map as a struct field when there was no struct enclosing the map. Same fix for arrays.