### PR TITLE
Fixed string alias annotation problem

### DIFF
--- a/rdl/parser.go
+++ b/rdl/parser.go
@@ -1157,7 +1157,7 @@ func (p *parser) parseStringTypeDef(t *StringTypeDef, base string) *StringTypeDe
 		}
 	}
 	t.Comment = p.statementEnd(t.Comment)
-	if t.MaxSize == nil && t.MinSize == nil && t.Pattern == "" && t.Values == nil {
+	if t.MaxSize == nil && t.MinSize == nil && t.Pattern == "" && t.Values == nil && t.Annotations == nil {
 		return nil
 	}
 	return t

--- a/rdl/parser_test.go
+++ b/rdl/parser_test.go
@@ -497,3 +497,15 @@ type Foo Struct {
 		return
 	}
 }
+
+func TestAliasAnnotation(test *testing.T) {
+	_, err := parseRDLString(`
+	   type DateTime string (x_date_time)
+	   type Response struct {
+	     DateTime dateTime (optional);
+	   }`)
+	if err != nil {
+		test.Errorf("cannot parse valid RDL: %v", err)
+		return
+	}
+}


### PR DESCRIPTION
Issue #50. Happened when a string alias type (with no actual type
restrictions occurred) was annotated.