### PR TITLE
avoid panic on nil Type in all in resolveRef

### DIFF
--- a/rdl/schemabuilder.go
+++ b/rdl/schemabuilder.go
@@ -6,6 +6,7 @@ package rdl
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 )
 
@@ -121,6 +122,10 @@ func (sb *SchemaBuilder) resolve(ordered []*Type, resolved map[string]bool, all 
 func (sb *SchemaBuilder) resolveRef(ordered []*Type, resolved map[string]bool, all map[string]*Type, ref string) []*Type {
 	if !sb.isBaseType(ref) {
 		t := all[ref]
+		if t == nil {
+			log.Printf("rdl-go resolveRef error: nil Type for ref=%s", ref)
+			return nil
+		}
 		_, super, _ := TypeInfo(t)
 		ordered = sb.resolve(ordered, resolved, all, ref, strings.ToLower(string(super)))
 	}

--- a/rdl/version.go
+++ b/rdl/version.go
@@ -3,4 +3,4 @@
 
 package rdl
 
-const Version = "1.4.14"
+const Version = "1.4.15"

--- a/testdata/rdl_schema.json
+++ b/testdata/rdl_schema.json
@@ -703,7 +703,7 @@
             "StructTypeDef": {
                 "type": "Struct",
                 "name": "Schema",
-                "comment": "A Schema is a container for types and resources. It is self-contained (no external references). and is the output of the RDL parser.",
+                "comment": "A Schema is a container for types and resources. It is self-contained (no external references) and is the output of the RDL parser.",
                 "fields": [
                     {
                         "name": "namespace",


### PR DESCRIPTION
we  are seeing an intermittent panic (below) from `init()` - so far was not able to reproduce it yet, but would like to add the missing nil check to print an informative error instead of dying.  When adding the nil check, I notice that this case is not covered by unit tests - need to figure out how to trigger it or why it can happen that `all` does not have an entry for that type)

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6e0f56]

goroutine 1 [running]:
vendor/github.com/ardielle/ardielle-go/rdl.TypeInfo(0x0, 0xc420132478, 0xc420014920, 0x7, 0x138bfe0, 0xc420014910, 0xc4201322a8)
	/buildroot/src/vendor/github.com/ardielle/ardielle-go/rdl/types.go:79 +0x26
vendor/github.com/ardielle/ardielle-go/rdl.(*SchemaBuilder).resolveRef(0xc4201335b0, 0xc42008c540, 0x6, 0x8, 0xc420132448, 0xc420132478, 0xc420014920, 0x7, 0xa, 0x4, ...)
	/buildroot/src/vendor/github.com/ardielle/ardielle-go/rdl/schemabuilder.go:124 +0xd4
vendor/github.com/ardielle/ardielle-go/rdl.(*SchemaBuilder).resolve(0xc4201335b0, 0xc42008c540, 0x6, 0x8, 0xc420132448, 0xc420132478, 0xc4200148e6, 0x7, 0xc42001490a, 0x6, ...)
	/buildroot/src/vendor/github.com/ardielle/ardielle-go/rdl/schemabuilder.go:111 +0x283
vendor/github.com/ardielle/ardielle-go/rdl.(*SchemaBuilder).Build(0xc4201335b0, 0xc420013260)
	/buildroot/src/vendor/github.com/ardielle/ardielle-go/rdl/schemabuilder.go:72 +0x3ec
vendor/github.com/ardielle/ardielle-go/rdl.init.0()
	/buildroot/src/vendor/github.com/ardielle/ardielle-go/rdl/rdl_schema.go:238 +0x86ee
vendor/github.com/ardielle/ardielle-go/rdl.init()
	<autogenerated>:1 +0xf0
```