### PR TITLE
BuildParanoid in SchemaBuilder

### DIFF
--- a/rdl/codegen/generator.go
+++ b/rdl/codegen/generator.go
@@ -129,6 +129,8 @@ var schemaTemplate = template.Must(template.New("").Funcs(funcMap).Parse(`// go 
 package {{ .Name }}
 
 import (
+	"log"
+
 	rdl "github.com/ardielle/ardielle-go/rdl"
 )
 
@@ -154,7 +156,11 @@ func init() {
 {{- end }}
 	sb.AddType(tStringStruct.Build())
 
-	schema = sb.Build()
+	var err error
+	schema, err = sb.BuildParanoid()
+	if err != nil {
+		log.Fatalf("sb.Build error: %s", err)
+	}
 }
 
 func {{ Title .Name -}}Schema() *rdl.Schema {

--- a/rdl/rdl_schema.go
+++ b/rdl/rdl_schema.go
@@ -4,6 +4,8 @@
 
 package rdl
 
+import "log"
+
 var schema *Schema
 
 func init() {
@@ -235,7 +237,11 @@ func init() {
 	tSchema.MapField("annotations", "ExtendedAnnotation", "String", true, "additional annotations starting with \"x_\"")
 	sb.AddType(tSchema.Build())
 
-	schema = sb.Build()
+	var err error
+	schema, err = sb.BuildParanoid()
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func RdlSchema() *Schema {

--- a/rdl/schemabuilder_test.go
+++ b/rdl/schemabuilder_test.go
@@ -30,7 +30,10 @@ func TestSchemaBuilder(test *testing.T) {
 	tb.Field("field1", "Timestamp", false, nil, "The timestamp field")
 	tb.Field("field2", "UUID", false, nil, "The uuid field")
 	sb.AddType(tb.Build())
-	schema = sb.Build()
+	schema, err = sb.BuildParanoid()
+	if err != nil {
+		test.Fatal(err)
+	}
 	if schema == nil {
 		test.Errorf("TestSchemaBuilder: Cannot build schema with certain base types")
 	}
@@ -154,7 +157,10 @@ func TestSBBaseTypeCaseSensitivity(test *testing.T) {
 			default:
 				test.Skipf("Basetype %s not tested", baseTypeName)
 			}
-			schema := sb.Build()
+			schema, err := sb.BuildParanoid()
+			if err != nil {
+				test.Fatal(err)
+			}
 			if schema == nil {
 				test.Errorf("TestSBBaseTypeCaseSensitivity: Cannot build schema")
 			}

--- a/rdl/validator_test.go
+++ b/rdl/validator_test.go
@@ -61,7 +61,10 @@ func TestValidatorCustomTypes(test *testing.T) {
 	sb.AddType(tTypeName.Build())
 
 	// Build the schema
-	schema := sb.Build()
+	schema, err := sb.BuildParanoid()
+	if err != nil {
+		test.Fatal(err)
+	}
 
 	// Types that define their own Validate can do whatever they want regarding
 	// whether a type validates or not (including not checking sub fields)

--- a/rdl/version.go
+++ b/rdl/version.go
@@ -3,4 +3,4 @@
 
 package rdl
 
-const Version = "1.4.15"
+const Version = "1.4.16"

--- a/rdl/version.go
+++ b/rdl/version.go
@@ -3,4 +3,4 @@
 
 package rdl
 
-const Version = "1.4.16"
+const Version = "1.5.0"


### PR DESCRIPTION
PR adds `BuildParanoid` function to SchemaBuilder to enable reporting errors while still preserving the API compatibility with the old `Build` method (which now wraps `BuildParanoid` but ignores and drops the error).  A PR in ardielle-tools using `BuildParanoid` in code generation follows.

@maditya